### PR TITLE
MaterialEditor の MOVE_TO_OTHER_INVENTORY の挙動を修正

### DIFF
--- a/src/main/java/jp/mincra/mincramagics/gui/GUI.java
+++ b/src/main/java/jp/mincra/mincramagics/gui/GUI.java
@@ -5,13 +5,11 @@ import jp.mincra.mincramagics.gui.lib.Screen;
 import jp.mincra.mincramagics.gui.lib.GUIHelper;
 import jp.mincra.mincramagics.gui.lib.Component;
 import jp.mincra.mincramagics.gui.lib.State;
+import jp.mincra.mincramagics.utils.Strings;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryAction;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.*;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 
@@ -92,7 +90,7 @@ public abstract class GUI implements Listener {
     protected final <T> State<T> useState(@NotNull T initialValue) {
         final int thisIndex = ++lastStateIndex;
         final T currentState = getStateOrDefault(thisIndex, initialValue);
-        MincraLogger.debug("[useState] thisIndex: " + thisIndex + ", states: " + states + ", currentState: " + currentState);
+        MincraLogger.debug("[useState] lastStateIndex: " + thisIndex + ", states: " + Strings.truncate(states) + ", currentState: " + Strings.truncate(currentState));
         if (thisIndex < states.size()) {
             states.set(thisIndex, currentState);
         } else {
@@ -202,20 +200,17 @@ public abstract class GUI implements Listener {
     public void onClick(InventoryClickEvent event) {
         if (!event.getInventory().equals(getInventory())) return;
 
-        final var slot = event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
-                ? GUIHelper.getTopLeftEmptySlot(event.getInventory())
+        final var destinationSlot = event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
+                ? GUIHelper.calculateDestinationSlot(event)
                 : event.getRawSlot();
+        MincraLogger.debug("[onClick] rawSlot: " + event.getRawSlot() + ", slot: " + event.getSlot() + ", action: " + event.getAction() + ", destination slot: " + destinationSlot);
 
-        event.setCancelled(!isModifiableSlot.test(
-                event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
-                        ? event.getRawSlot()
-                        : slot
-        ));
+        event.setCancelled(!isModifiableSlot.test(event.getRawSlot()));
 
 //        MincraLogger.debug("[onClick] states: " + states);
-        if (clickListeners.containsKey(slot)) {
+        if (clickListeners.containsKey(destinationSlot)) {
 //            MincraLogger.debug("[onClick] clickListeners.get(slot).size: " + clickListeners.get(slot).size());
-            for (Consumer<InventoryClickEvent> listener : clickListeners.get(slot)) {
+            for (Consumer<InventoryClickEvent> listener : clickListeners.get(destinationSlot)) {
 //                MincraLogger.debug("[onClick] clickListeners.get(slot)");
                 listener.accept(event);
 //                MincraLogger.debug("[onClick] after listener.accept(event) states: " + states);

--- a/src/main/java/jp/mincra/mincramagics/gui/lib/Component.java
+++ b/src/main/java/jp/mincra/mincramagics/gui/lib/Component.java
@@ -27,8 +27,8 @@ public abstract class Component {
     // Primitive listener adders
 
     protected void addClickListener(int index, Consumer<InventoryClickEvent> listener) {
-        if (index <= -1) {
-            MincraLogger.warn("Do not use negative index except -1 (any slot). Use addClickListener(Consumer<InventoryClickEvent>) instead.");
+        if (index < -1) {
+            MincraLogger.warn("Do not use negative index except -1 (any slot). Got " + index + ". Use addClickListener(Consumer<InventoryClickEvent>) instead.");
         }
         if (!clickListeners.containsKey(index)) {
             clickListeners.put(index, new ArrayList<>());

--- a/src/main/java/jp/mincra/mincramagics/utils/Strings.java
+++ b/src/main/java/jp/mincra/mincramagics/utils/Strings.java
@@ -1,0 +1,14 @@
+package jp.mincra.mincramagics.utils;
+
+public class Strings {
+    public static String truncate(Object obj, int maxLength) {
+        if (obj == null) return null;
+        final var str = obj.toString();
+        if (str.length() <= maxLength) return str;
+        return str.substring(0, maxLength - 3) + "...";
+    }
+
+    public static String truncate(Object obj) {
+        return truncate(obj, 32);
+    }
+}


### PR DESCRIPTION
## 説明



## 変更点



## その他のコードやファイル (`.yaml`, `.png` など)


