### PR TITLE
「ブラッドソードのスキル追加」でのミス修正

### DIFF
--- a/src/main/java/jp/mincra/mincramagics/MincraMagics.java
+++ b/src/main/java/jp/mincra/mincramagics/MincraMagics.java
@@ -28,6 +28,8 @@ import jp.mincra.mincramagics.skill.MaterialManager;
 import jp.mincra.mincramagics.skill.SkillManager;
 import jp.mincra.mincramagics.skill.combat.*;
 import jp.mincra.mincramagics.skill.healing.Heal;
+import jp.mincra.mincramagics.skill.job.hunter.*;
+import jp.mincra.mincramagics.skill.job.miner.*;
 import jp.mincra.mincramagics.skill.passive.*;
 import jp.mincra.mincramagics.skill.utility.*;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
@@ -114,7 +116,6 @@ public final class MincraMagics extends JavaPlugin {
         skillManager.registerSkill("hp_recovery", new HpRecovery());
         skillManager.registerSkill("mp_recovery", new MpRecovery());
         skillManager.registerSkill("bleeding", new Bleeding());
-
         // Utility
         skillManager.registerSkill("charge", new Charge());
         skillManager.registerSkill("charging", new Charging());

--- a/src/main/java/jp/mincra/mincramagics/skill/passive/Bleeding.java
+++ b/src/main/java/jp/mincra/mincramagics/skill/passive/Bleeding.java
@@ -1,6 +1,7 @@
 package jp.mincra.mincramagics.skill.passive;
 
 import jp.mincra.bkvfx.Vfx;
+import jp.mincra.mincramagics.MincraLogger;
 import jp.mincra.mincramagics.MincraMagics;
 import jp.mincra.mincramagics.skill.MagicSkill;
 import jp.mincra.mincramagics.skill.MaterialProperty;
@@ -20,7 +21,6 @@ import java.util.UUID;
 import java.util.logging.Logger;
 
 public class Bleeding extends MagicSkill implements Listener {
-    private final Logger logger = MincraMagics.getPluginLogger();
     private final Map<UUID, BleedingInstance> bleedingInstances = new HashMap<>();
     private record BleedingInstance(double healRate) {}
 
@@ -48,7 +48,7 @@ public class Bleeding extends MagicSkill implements Listener {
         if (bleedingInstances.containsKey(player.getUniqueId())) {
             bleedingInstances.remove(player.getUniqueId());
         } else {
-            logger.warning("Player " + player.getName() + " does not have hp_recovery metadata.");
+            MincraLogger.warn("Player " + player.getName() + " does not have bleedingInstance.");
         }
     }
 


### PR DESCRIPTION
## 説明
[ブラッドソードのスキル追加](https://github.com/MincraServer/MincraMagics/pull/27)で色々なミスをしていましたので、修正しました。

主に確認をせずにコンフリクト解消をしたせいです。
同様のミスを再度起こさないよう、コンフリクト解消時に何度かチェックをすることで対策を行います。
誠に申し訳ございませんでした。

### やらかしリスト
- ``job``の``import``を削除。
- ログのクラス変更に対応できていなかった。
- ログのメッセージをコピペしたままで変更していない。

## 変更点
- ``job``の``import``を追加(ワイルドカードに変更)
- ログのクラスを現状のものに変更
- ログのメッセージを適切なものに変更

## その他のコードやファイル (`.yaml`, `.png` など)
特になし。
